### PR TITLE
Change type of created folders from "meta" to "folder"

### DIFF
--- a/CreateAlias.js
+++ b/CreateAlias.js
@@ -79,7 +79,7 @@ function createAlias(idSrc, idDst,raum, gewerk,typeAlias, read, write, nameAlias
                     let bApply = false;
                     if(obj != undefined){
                         if(obj.type == undefined || String(obj.type) != 'meta'){
-                            obj.type = 'meta';
+                            obj.type = 'folder';
                             bApply = true;
                         }
                         if(obj.common == undefined){


### PR DESCRIPTION
To match behavior of iobroker.devices adapter at creation of folders.